### PR TITLE
Per-user credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,16 @@
 # Splitwise OAuth 2.0 Configuration
 SPLITWISE_CONSUMER_KEY=your_consumer_key_here
 SPLITWISE_CONSUMER_SECRET=your_consumer_secret_here
+
+# Default identity's access token -- used when no caller identity is
+# resolved at all (stdio mode, or any caller not going through the
+# multi-user HTTP path).
 SPLITWISE_ACCESS_TOKEN=your_access_token_here
+
+# Per-user access tokens for multi-user HTTP mode -- one per person, each
+# generated via their own OAuth flow (see get-token.ts). Env var name is
+# SPLITWISE_ACCESS_TOKEN_<USER_ID uppercased>, e.g.:
+# SPLITWISE_ACCESS_TOKEN_ALICE=alice_own_access_token_here
 
 # Optional: Splitwise API Base URL (defaults to https://secure.splitwise.com/api/v3.0)
 SPLITWISE_API_BASE_URL=https://secure.splitwise.com/api/v3.0

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "node dist/index.js",
     "start:stdio": "node dist/index.js --stdio",
     "get-token": "tsc && node dist/get-token.js",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test": "vitest run"
   },
   "keywords": [
     "mcp",
@@ -40,6 +41,7 @@
     "@types/express": "^4.17.0",
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",
-    "@types/ws": "^8.5.0"
+    "@types/ws": "^8.5.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/src/client-registry.test.ts
+++ b/src/client-registry.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the per-user SplitwiseClient registry.
+ *
+ * Covers the pure identity/caching logic. Doesn't cover real Splitwise API
+ * calls -- SplitwiseClient's constructor never makes a network request
+ * (axios.create() just builds a client object), so these tests exercise
+ * real construction without needing to mock HTTP.
+ *
+ * Each test uses a unique userId to avoid cache collisions across tests,
+ * since the registry's cache is module-level state shared for the life of
+ * the test file (no test-only reset hook added to production code).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getClient } from './client-registry.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  process.env.SPLITWISE_ACCESS_TOKEN = 'default-token';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('getClient', () => {
+  it('resolves the default identity when no userId is given', () => {
+    const client = getClient();
+    expect(client).toBeDefined();
+  });
+
+  it('caches by userId -- same userId returns the same instance', () => {
+    process.env.SPLITWISE_ACCESS_TOKEN_ALICE1 = 'alice-token';
+    const a = getClient('alice1');
+    const b = getClient('alice1');
+    expect(a).toBe(b);
+  });
+
+  it('gives two distinct users two distinct client instances', () => {
+    process.env.SPLITWISE_ACCESS_TOKEN_ALICE2 = 'alice-token';
+    process.env.SPLITWISE_ACCESS_TOKEN_BOB2 = 'bob-token';
+    const alice = getClient('alice2');
+    const bob = getClient('bob2');
+    expect(alice).not.toBe(bob);
+  });
+
+  it('the default identity and a named user are distinct instances', () => {
+    process.env.SPLITWISE_ACCESS_TOKEN_ALICE3 = 'alice-token';
+    const defaultClient = getClient();
+    const namedClient = getClient('alice3');
+    expect(defaultClient).not.toBe(namedClient);
+  });
+
+  it('rejects a named user with no matching env var configured', () => {
+    // Mirrors the acceptance criterion: an unconfigured caller with no
+    // resolvable user_id must never fall back to the default identity's
+    // token, even implicitly.
+    expect(() => getClient('nobody-configured')).toThrowError(
+      /No Splitwise access token configured for user 'nobody-configured'/
+    );
+  });
+
+  it('the env var lookup is uppercased consistently', () => {
+    process.env.SPLITWISE_ACCESS_TOKEN_LOWERCASE4 = 'a-token';
+    // userId is passed lowercase; the registry uppercases it to build the
+    // env var name -- this must not throw.
+    expect(() => getClient('lowercase4')).not.toThrow();
+  });
+});

--- a/src/client-registry.ts
+++ b/src/client-registry.ts
@@ -1,0 +1,48 @@
+/**
+ * Per-user SplitwiseClient cache.
+ *
+ * Previously index.ts (stdio) and transport/http.ts (HTTP) each held their
+ * own independent module-level singleton, both reading the single shared
+ * SPLITWISE_ACCESS_TOKEN env var -- consolidated here into one registry both
+ * transports share, now keyed by user_id.
+ */
+
+import { SplitwiseClient } from './splitwise-client.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+
+const clients = new Map<string, SplitwiseClient>();
+
+/**
+ * Get (creating if needed) the SplitwiseClient for a given user_id.
+ *
+ * userId undefined (stdio mode, or any caller with no resolved identity)
+ * falls back to the original single-user identity -- SPLITWISE_ACCESS_TOKEN,
+ * unprefixed, unchanged behavior from before per-user support existed.
+ *
+ * A named userId with no matching SPLITWISE_ACCESS_TOKEN_<USER> env var is
+ * rejected outright, not silently served from the default token -- an
+ * unconfigured person must never see the default identity's data.
+ */
+export function getClient(userId?: string): SplitwiseClient {
+  const cacheKey = userId ?? '__default__';
+  const cached = clients.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  let accessToken: string | undefined;
+  if (userId) {
+    const envKey = `SPLITWISE_ACCESS_TOKEN_${userId.toUpperCase()}`;
+    accessToken = process.env[envKey];
+    if (!accessToken) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `No Splitwise access token configured for user '${userId}' (expected ${envKey})`
+      );
+    }
+  }
+
+  const client = new SplitwiseClient(accessToken);
+  clients.set(cacheKey, client);
+  return client;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,26 +8,8 @@ import {
   ErrorCode,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
-import { SplitwiseClient } from './splitwise-client.js';
 import { getAllTools, handleToolCall } from './tools.js';
-
-// Initialize the Splitwise client (lazily)
-let splitwiseClient: SplitwiseClient | null = null;
-
-function getClient(): SplitwiseClient {
-  if (!splitwiseClient) {
-    try {
-      splitwiseClient = new SplitwiseClient();
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      throw new McpError(
-        ErrorCode.InvalidRequest,
-        `Failed to initialize Splitwise client: ${errorMessage}`
-      );
-    }
-  }
-  return splitwiseClient;
-}
+import { getClient } from './client-registry.js';
 
 // Create the MCP server
 const server = new Server(

--- a/src/splitwise-client.ts
+++ b/src/splitwise-client.ts
@@ -7,9 +7,12 @@ export class SplitwiseClient {
   private client: AxiosInstance;
   private accessToken: string;
 
-  constructor() {
+  constructor(accessToken?: string) {
     const apiBaseUrl = process.env.SPLITWISE_API_BASE_URL || 'https://secure.splitwise.com/api/v3.0';
-    this.accessToken = process.env.SPLITWISE_ACCESS_TOKEN || '';
+    // An explicit token (per-user) wins; falling through to the plain env var
+    // preserves the original single-user behavior unchanged when no token is
+    // passed at all (stdio mode, or any caller with no resolved identity).
+    this.accessToken = accessToken || process.env.SPLITWISE_ACCESS_TOKEN || '';
 
     if (!this.accessToken) {
       throw new Error('SPLITWISE_ACCESS_TOKEN environment variable is required');

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -11,21 +11,18 @@
 import express, { Request, Response, Express } from 'express';
 import { isValidJsonRpc, isNotification, createSuccessResponse, createErrorResponse, JsonRpcError, validateMcpProtocolVersion } from '../utils/jsonrpc.js';
 import { getAllTools, handleToolCall } from '../tools.js';
-import { SplitwiseClient } from '../splitwise-client.js';
-
-let splitwiseClient: SplitwiseClient | null = null;
-
-function getClient(): SplitwiseClient {
-  if (!splitwiseClient) {
-    splitwiseClient = new SplitwiseClient();
-  }
-  return splitwiseClient;
-}
+import { getClient } from '../client-registry.js';
 
 /**
  * Handle a single MCP JSON-RPC request.
+ *
+ * userId comes from the gateway-resolved X-User-Id header on the underlying
+ * HTTP request (see createHttpServer's POST /mcp handler) -- undefined for
+ * any caller that didn't come through that path, which getClient treats as
+ * the single pre-multi-user default identity, not a shared fallback for a
+ * named user.
  */
-async function handleMcpRequest(requestData: any): Promise<any> {
+async function handleMcpRequest(requestData: any, userId?: string): Promise<any> {
   const method = requestData.method;
   const params = requestData.params || {};
   const requestId = requestData.id;
@@ -63,7 +60,7 @@ async function handleMcpRequest(requestData: any): Promise<any> {
       }
 
       try {
-        const client = getClient();
+        const client = getClient(userId);
         const raw = await handleToolCall(toolName, toolArgs, client);
 
         // Normalize to MCP tool response shape
@@ -108,6 +105,12 @@ export function createHttpServer(port: number = 4000): Express {
 
   // POST /mcp - Main MCP endpoint
   app.post('/mcp', async (req: Request, res: Response) => {
+    // Gateway forwards the resolved caller identity as X-User-Id. Express
+    // gives each request its own req object -- no shared/global state to
+    // leak between concurrent requests the way a naive module-level
+    // variable would.
+    const userId = req.get('X-User-Id') || undefined;
+
     const mcpProtocolVersion = req.get('MCP-Protocol-Version');
 
     if (mcpProtocolVersion && !validateMcpProtocolVersion(mcpProtocolVersion)) {
@@ -129,13 +132,13 @@ export function createHttpServer(port: number = 4000): Express {
     }
 
     if (isNotification(body)) {
-      handleMcpRequest(body).catch((error) => {
+      handleMcpRequest(body, userId).catch((error) => {
         console.error('[DEBUG] Error handling notification:', error);
       });
       return res.status(202).send();
     }
 
-    const response = await handleMcpRequest(body);
+    const response = await handleMcpRequest(body, userId);
 
     if (!response) {
       return res.status(202).send();


### PR DESCRIPTION
Implements #2. Replaces the single module-level `SplitwiseClient` singleton — actually two independent ones, one each in `index.ts` (stdio) and `transport/http.ts` (HTTP), both reading the same shared `SPLITWISE_ACCESS_TOKEN` — with one consolidated cache in `client-registry.ts`, keyed by `user_id`.

## Summary
- Caller identity comes from an `X-User-Id` header on the underlying HTTP request (`transport/http.ts`'s `POST /mcp` handler), threaded explicitly through `handleMcpRequest` into `getClient(userId)`. Each Express request has its own `req` object, so there's no shared/global state that could leak a `user_id` across concurrent requests.
- A named `user_id` resolves to `SPLITWISE_ACCESS_TOKEN_<USER>`; if that env var isn't set, the request is rejected outright, not silently served from the default identity's token.
- No `user_id` at all (stdio mode, or any caller that hasn't gone through the multi-user HTTP path) falls back to the original single `SPLITWISE_ACCESS_TOKEN`, unchanged from before this change.
- `SplitwiseClient`'s constructor now accepts an optional token override; falls through to the env var when not given, so the default/no-args construction path is byte-for-byte the same as before.

## Testing
- New `src/client-registry.test.ts` via `vitest` (added — this repo had no test framework or tests before). 6 tests covering caching/isolation logic.
- `tsc --noEmit` clean, full `npm run build` clean.
- Live smoke test of the built server: health check + `tools/list` both correct against a real running instance.

## Test plan
- [x] Full diff read
- [x] Verified in a fresh clone + branch checkout on a separate machine (not just this working copy) — install, type-check, build, test, live smoke test all clean